### PR TITLE
Read test dll and attributes for listing tests to run

### DIFF
--- a/Extensions.cs
+++ b/Extensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LocalTestPortal
+{
+    public static class Extensions
+    {
+        /// <summary>
+        /// For a given string which could be split on comma convert to a list
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        public static List<string> ToSplitList(this string s)
+        {
+            return !string.IsNullOrWhiteSpace(s) ? s.Split(',').ToList() : null;
+        }
+
+        /// <summary>
+        /// Convert list of strings to single joined string on comma
+        /// </summary>
+        public static string ToJoinedString(this List<string> s)
+        {
+            return s == null ? null : string.Join(",", s.ToArray());
+        }
+    }
+}

--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -33,6 +33,9 @@ namespace LocalTestPortal
             this.tabPage1 = new System.Windows.Forms.TabPage();
             this.gridTests = new System.Windows.Forms.DataGridView();
             this.tabPage4 = new System.Windows.Forms.TabPage();
+            this.label13 = new System.Windows.Forms.Label();
+            this.label12 = new System.Windows.Forms.Label();
+            this.txtTestDllFileNames = new System.Windows.Forms.TextBox();
             this.label9 = new System.Windows.Forms.Label();
             this.txtPlaySound = new System.Windows.Forms.TextBox();
             this.label8 = new System.Windows.Forms.Label();
@@ -63,11 +66,16 @@ namespace LocalTestPortal
             this.cSettings = new System.Windows.Forms.ComboBox();
             this.btnSaveSettings = new System.Windows.Forms.Button();
             this.btnRunTests = new System.Windows.Forms.Button();
+            this.loadSettingsButton = new System.Windows.Forms.Button();
+            this.label14 = new System.Windows.Forms.Label();
+            this.label15 = new System.Windows.Forms.Label();
+            this.lblTestGridInfo = new System.Windows.Forms.Label();
             this.Selected = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.TestName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.TestModule = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Result = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.LogFile = new System.Windows.Forms.DataGridViewLinkColumn();
-			this.loadSettingsButton = new System.Windows.Forms.Button();
+            this.TestDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.gridTests)).BeginInit();
@@ -84,19 +92,20 @@ namespace LocalTestPortal
             this.tabControl1.Controls.Add(this.tabPage2);
             this.tabControl1.Controls.Add(this.tabPage3);
             this.tabControl1.Controls.Add(this.tabPage5);
-            this.tabControl1.Location = new System.Drawing.Point(12, 106);
+            this.tabControl1.Location = new System.Drawing.Point(12, 51);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(826, 490);
+            this.tabControl1.Size = new System.Drawing.Size(1141, 609);
             this.tabControl1.TabIndex = 1;
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.lblTestGridInfo);
             this.tabPage1.Controls.Add(this.gridTests);
             this.tabPage1.Location = new System.Drawing.Point(4, 22);
             this.tabPage1.Name = "tabPage1";
             this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(818, 464);
+            this.tabPage1.Size = new System.Drawing.Size(1133, 583);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Tests";
             this.tabPage1.UseVisualStyleBackColor = true;
@@ -109,16 +118,23 @@ namespace LocalTestPortal
             this.gridTests.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Selected,
             this.TestName,
+            this.TestModule,
             this.Result,
-            this.LogFile});
+            this.LogFile,
+            this.TestDescription});
             this.gridTests.Location = new System.Drawing.Point(6, 6);
             this.gridTests.Name = "gridTests";
-            this.gridTests.Size = new System.Drawing.Size(806, 438);
+            this.gridTests.Size = new System.Drawing.Size(1121, 558);
             this.gridTests.TabIndex = 0;
             this.gridTests.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.gridTests_CellContentClick);
             // 
             // tabPage4
             // 
+            this.tabPage4.Controls.Add(this.label15);
+            this.tabPage4.Controls.Add(this.label14);
+            this.tabPage4.Controls.Add(this.label13);
+            this.tabPage4.Controls.Add(this.label12);
+            this.tabPage4.Controls.Add(this.txtTestDllFileNames);
             this.tabPage4.Controls.Add(this.label9);
             this.tabPage4.Controls.Add(this.txtPlaySound);
             this.tabPage4.Controls.Add(this.label8);
@@ -126,15 +142,40 @@ namespace LocalTestPortal
             this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
             this.tabPage4.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage4.Size = new System.Drawing.Size(788, 464);
+            this.tabPage4.Size = new System.Drawing.Size(818, 464);
             this.tabPage4.TabIndex = 3;
             this.tabPage4.Text = "General";
             this.tabPage4.UseVisualStyleBackColor = true;
             // 
+            // label13
+            // 
+            this.label13.AutoSize = true;
+            this.label13.Location = new System.Drawing.Point(157, 48);
+            this.label13.Name = "label13";
+            this.label13.Size = new System.Drawing.Size(247, 13);
+            this.label13.TabIndex = 8;
+            this.label13.Text = "Location of TestProject.exe and related test dll files";
+            // 
+            // label12
+            // 
+            this.label12.AutoSize = true;
+            this.label12.Location = new System.Drawing.Point(20, 79);
+            this.label12.Name = "label12";
+            this.label12.Size = new System.Drawing.Size(99, 13);
+            this.label12.TabIndex = 7;
+            this.label12.Text = "Test dll File Names:";
+            // 
+            // txtTestDllFileNames
+            // 
+            this.txtTestDllFileNames.Location = new System.Drawing.Point(160, 76);
+            this.txtTestDllFileNames.Name = "txtTestDllFileNames";
+            this.txtTestDllFileNames.Size = new System.Drawing.Size(593, 20);
+            this.txtTestDllFileNames.TabIndex = 6;
+            // 
             // label9
             // 
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(20, 66);
+            this.label9.Location = new System.Drawing.Point(20, 134);
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(134, 13);
             this.label9.TabIndex = 5;
@@ -142,7 +183,7 @@ namespace LocalTestPortal
             // 
             // txtPlaySound
             // 
-            this.txtPlaySound.Location = new System.Drawing.Point(160, 63);
+            this.txtPlaySound.Location = new System.Drawing.Point(160, 131);
             this.txtPlaySound.Name = "txtPlaySound";
             this.txtPlaySound.Size = new System.Drawing.Size(593, 20);
             this.txtPlaySound.TabIndex = 4;
@@ -174,7 +215,7 @@ namespace LocalTestPortal
             this.tabPage2.Location = new System.Drawing.Point(4, 22);
             this.tabPage2.Name = "tabPage2";
             this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(788, 464);
+            this.tabPage2.Size = new System.Drawing.Size(818, 464);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "Database";
             this.tabPage2.UseVisualStyleBackColor = true;
@@ -241,7 +282,7 @@ namespace LocalTestPortal
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
             this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage3.Size = new System.Drawing.Size(788, 464);
+            this.tabPage3.Size = new System.Drawing.Size(818, 464);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Browser";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -330,7 +371,7 @@ namespace LocalTestPortal
             this.tabPage5.Location = new System.Drawing.Point(4, 22);
             this.tabPage5.Name = "tabPage5";
             this.tabPage5.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage5.Size = new System.Drawing.Size(788, 464);
+            this.tabPage5.Size = new System.Drawing.Size(818, 464);
             this.tabPage5.TabIndex = 4;
             this.tabPage5.Text = "Logging";
             this.tabPage5.UseVisualStyleBackColor = true;
@@ -398,13 +439,52 @@ namespace LocalTestPortal
             // 
             // btnRunTests
             // 
-            this.btnRunTests.Location = new System.Drawing.Point(540, 39);
+            this.btnRunTests.Location = new System.Drawing.Point(1024, 12);
             this.btnRunTests.Name = "btnRunTests";
             this.btnRunTests.Size = new System.Drawing.Size(119, 33);
             this.btnRunTests.TabIndex = 3;
             this.btnRunTests.Text = "Run Tests";
             this.btnRunTests.UseVisualStyleBackColor = true;
             this.btnRunTests.Click += new System.EventHandler(this.btnRunTests_Click);
+            // 
+            // loadSettingsButton
+            // 
+            this.loadSettingsButton.AccessibleRole = System.Windows.Forms.AccessibleRole.ScrollBar;
+            this.loadSettingsButton.Location = new System.Drawing.Point(263, 12);
+            this.loadSettingsButton.Name = "loadSettingsButton";
+            this.loadSettingsButton.Size = new System.Drawing.Size(87, 23);
+            this.loadSettingsButton.TabIndex = 4;
+            this.loadSettingsButton.Text = "Load Settings";
+            this.loadSettingsButton.UseVisualStyleBackColor = true;
+            this.loadSettingsButton.Click += new System.EventHandler(this.loadSettingsButton_Click);
+            // 
+            // label14
+            // 
+            this.label14.AutoSize = true;
+            this.label14.Location = new System.Drawing.Point(157, 99);
+            this.label14.Name = "label14";
+            this.label14.Size = new System.Drawing.Size(489, 13);
+            this.label14.TabIndex = 9;
+            this.label14.Text = "List of all test dll file names. Not required to inlclude .dll and can include mu" +
+    "ltiple seperated by a comma";
+            // 
+            // label15
+            // 
+            this.label15.AutoSize = true;
+            this.label15.Location = new System.Drawing.Point(157, 154);
+            this.label15.Name = "label15";
+            this.label15.Size = new System.Drawing.Size(276, 13);
+            this.label15.TabIndex = 10;
+            this.label15.Text = "Default example sound: C:\\Windows\\Media\\Ring01.wav";
+            // 
+            // lblTestGridInfo
+            // 
+            this.lblTestGridInfo.AutoSize = true;
+            this.lblTestGridInfo.Location = new System.Drawing.Point(3, 567);
+            this.lblTestGridInfo.Name = "lblTestGridInfo";
+            this.lblTestGridInfo.Size = new System.Drawing.Size(109, 13);
+            this.lblTestGridInfo.TabIndex = 1;
+            this.lblTestGridInfo.Text = "Grid Results: Pending";
             // 
             // Selected
             // 
@@ -418,6 +498,12 @@ namespace LocalTestPortal
             this.TestName.ReadOnly = true;
             this.TestName.Width = 200;
             // 
+            // TestModule
+            // 
+            this.TestModule.HeaderText = "Module";
+            this.TestModule.Name = "TestModule";
+            this.TestModule.Width = 125;
+            // 
             // Result
             // 
             this.Result.HeaderText = "Result";
@@ -430,22 +516,18 @@ namespace LocalTestPortal
             this.LogFile.Name = "LogFile";
             this.LogFile.ReadOnly = true;
             this.LogFile.Width = 310;
-            // loadSettingsButton
             // 
-            this.loadSettingsButton.AccessibleRole = System.Windows.Forms.AccessibleRole.ScrollBar;
-            this.loadSettingsButton.Location = new System.Drawing.Point(161, 41);
-            this.loadSettingsButton.Name = "loadSettingsButton";
-            this.loadSettingsButton.Size = new System.Drawing.Size(87, 23);
-            this.loadSettingsButton.TabIndex = 4;
-            this.loadSettingsButton.Text = "Load Settings";
-            this.loadSettingsButton.UseVisualStyleBackColor = true;
-            this.loadSettingsButton.Click += new System.EventHandler(this.loadSettingsButton_Click);
+            // TestDescription
+            // 
+            this.TestDescription.HeaderText = "Description";
+            this.TestDescription.Name = "TestDescription";
+            this.TestDescription.Width = 400;
             // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(850, 621);
+            this.ClientSize = new System.Drawing.Size(1165, 672);
             this.Controls.Add(this.loadSettingsButton);
             this.Controls.Add(this.btnRunTests);
             this.Controls.Add(this.btnSaveSettings);
@@ -455,6 +537,7 @@ namespace LocalTestPortal
             this.Text = "Local Test Portal";
             this.tabControl1.ResumeLayout(false);
             this.tabPage1.ResumeLayout(false);
+            this.tabPage1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.gridTests)).EndInit();
             this.tabPage4.ResumeLayout(false);
             this.tabPage4.PerformLayout();
@@ -504,11 +587,19 @@ namespace LocalTestPortal
         private System.Windows.Forms.TextBox txtScreenshotPath;
         private System.Windows.Forms.Label label10;
         private System.Windows.Forms.TextBox txtOutputPath;
+        private System.Windows.Forms.Button loadSettingsButton;
+        private System.Windows.Forms.Label label12;
+        private System.Windows.Forms.TextBox txtTestDllFileNames;
+        private System.Windows.Forms.Label label13;
+        private System.Windows.Forms.Label label14;
+        private System.Windows.Forms.Label label15;
+        private System.Windows.Forms.Label lblTestGridInfo;
         private System.Windows.Forms.DataGridViewCheckBoxColumn Selected;
         private System.Windows.Forms.DataGridViewTextBoxColumn TestName;
+        private System.Windows.Forms.DataGridViewTextBoxColumn TestModule;
         private System.Windows.Forms.DataGridViewTextBoxColumn Result;
         private System.Windows.Forms.DataGridViewLinkColumn LogFile;
-        private System.Windows.Forms.Button loadSettingsButton;
+        private System.Windows.Forms.DataGridViewTextBoxColumn TestDescription;
     }
 }
 

--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -31,8 +31,17 @@ namespace LocalTestPortal
         {
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.lblTestGridInfo = new System.Windows.Forms.Label();
             this.gridTests = new System.Windows.Forms.DataGridView();
+            this.Selected = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.TestName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.TestModule = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Result = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.LogFile = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.TestDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.tabPage4 = new System.Windows.Forms.TabPage();
+            this.label15 = new System.Windows.Forms.Label();
+            this.label14 = new System.Windows.Forms.Label();
             this.label13 = new System.Windows.Forms.Label();
             this.label12 = new System.Windows.Forms.Label();
             this.txtTestDllFileNames = new System.Windows.Forms.TextBox();
@@ -67,15 +76,6 @@ namespace LocalTestPortal
             this.btnSaveSettings = new System.Windows.Forms.Button();
             this.btnRunTests = new System.Windows.Forms.Button();
             this.loadSettingsButton = new System.Windows.Forms.Button();
-            this.label14 = new System.Windows.Forms.Label();
-            this.label15 = new System.Windows.Forms.Label();
-            this.lblTestGridInfo = new System.Windows.Forms.Label();
-            this.Selected = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.TestName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.TestModule = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Result = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.LogFile = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.TestDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.gridTests)).BeginInit();
@@ -87,6 +87,9 @@ namespace LocalTestPortal
             // 
             // tabControl1
             // 
+            this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControl1.Controls.Add(this.tabPage1);
             this.tabControl1.Controls.Add(this.tabPage4);
             this.tabControl1.Controls.Add(this.tabPage2);
@@ -110,10 +113,23 @@ namespace LocalTestPortal
             this.tabPage1.Text = "Tests";
             this.tabPage1.UseVisualStyleBackColor = true;
             // 
+            // lblTestGridInfo
+            // 
+            this.lblTestGridInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lblTestGridInfo.AutoSize = true;
+            this.lblTestGridInfo.Location = new System.Drawing.Point(3, 567);
+            this.lblTestGridInfo.Name = "lblTestGridInfo";
+            this.lblTestGridInfo.Size = new System.Drawing.Size(109, 13);
+            this.lblTestGridInfo.TabIndex = 1;
+            this.lblTestGridInfo.Text = "Grid Results: Pending";
+            // 
             // gridTests
             // 
             this.gridTests.AllowUserToAddRows = false;
             this.gridTests.AllowUserToDeleteRows = false;
+            this.gridTests.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.gridTests.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.gridTests.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Selected,
@@ -127,6 +143,43 @@ namespace LocalTestPortal
             this.gridTests.Size = new System.Drawing.Size(1121, 558);
             this.gridTests.TabIndex = 0;
             this.gridTests.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.gridTests_CellContentClick);
+            // 
+            // Selected
+            // 
+            this.Selected.HeaderText = "Selected";
+            this.Selected.Name = "Selected";
+            // 
+            // TestName
+            // 
+            this.TestName.HeaderText = "Test Name";
+            this.TestName.Name = "TestName";
+            this.TestName.ReadOnly = true;
+            this.TestName.Width = 200;
+            // 
+            // TestModule
+            // 
+            this.TestModule.HeaderText = "Module";
+            this.TestModule.Name = "TestModule";
+            this.TestModule.Width = 125;
+            // 
+            // Result
+            // 
+            this.Result.HeaderText = "Result";
+            this.Result.Name = "Result";
+            this.Result.ReadOnly = true;
+            // 
+            // LogFile
+            // 
+            this.LogFile.HeaderText = "Log File";
+            this.LogFile.Name = "LogFile";
+            this.LogFile.ReadOnly = true;
+            this.LogFile.Width = 310;
+            // 
+            // TestDescription
+            // 
+            this.TestDescription.HeaderText = "Description";
+            this.TestDescription.Name = "TestDescription";
+            this.TestDescription.Width = 400;
             // 
             // tabPage4
             // 
@@ -142,10 +195,29 @@ namespace LocalTestPortal
             this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
             this.tabPage4.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage4.Size = new System.Drawing.Size(818, 464);
+            this.tabPage4.Size = new System.Drawing.Size(1133, 583);
             this.tabPage4.TabIndex = 3;
             this.tabPage4.Text = "General";
             this.tabPage4.UseVisualStyleBackColor = true;
+            // 
+            // label15
+            // 
+            this.label15.AutoSize = true;
+            this.label15.Location = new System.Drawing.Point(157, 154);
+            this.label15.Name = "label15";
+            this.label15.Size = new System.Drawing.Size(276, 13);
+            this.label15.TabIndex = 10;
+            this.label15.Text = "Default example sound: C:\\Windows\\Media\\Ring01.wav";
+            // 
+            // label14
+            // 
+            this.label14.AutoSize = true;
+            this.label14.Location = new System.Drawing.Point(157, 99);
+            this.label14.Name = "label14";
+            this.label14.Size = new System.Drawing.Size(489, 13);
+            this.label14.TabIndex = 9;
+            this.label14.Text = "List of all test dll file names. Not required to inlclude .dll and can include mu" +
+    "ltiple seperated by a comma";
             // 
             // label13
             // 
@@ -215,7 +287,7 @@ namespace LocalTestPortal
             this.tabPage2.Location = new System.Drawing.Point(4, 22);
             this.tabPage2.Name = "tabPage2";
             this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(818, 464);
+            this.tabPage2.Size = new System.Drawing.Size(1133, 583);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "Database";
             this.tabPage2.UseVisualStyleBackColor = true;
@@ -282,7 +354,7 @@ namespace LocalTestPortal
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
             this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage3.Size = new System.Drawing.Size(818, 464);
+            this.tabPage3.Size = new System.Drawing.Size(1133, 583);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Browser";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -371,7 +443,7 @@ namespace LocalTestPortal
             this.tabPage5.Location = new System.Drawing.Point(4, 22);
             this.tabPage5.Name = "tabPage5";
             this.tabPage5.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage5.Size = new System.Drawing.Size(818, 464);
+            this.tabPage5.Size = new System.Drawing.Size(1133, 583);
             this.tabPage5.TabIndex = 4;
             this.tabPage5.Text = "Logging";
             this.tabPage5.UseVisualStyleBackColor = true;
@@ -457,71 +529,6 @@ namespace LocalTestPortal
             this.loadSettingsButton.Text = "Load Settings";
             this.loadSettingsButton.UseVisualStyleBackColor = true;
             this.loadSettingsButton.Click += new System.EventHandler(this.loadSettingsButton_Click);
-            // 
-            // label14
-            // 
-            this.label14.AutoSize = true;
-            this.label14.Location = new System.Drawing.Point(157, 99);
-            this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(489, 13);
-            this.label14.TabIndex = 9;
-            this.label14.Text = "List of all test dll file names. Not required to inlclude .dll and can include mu" +
-    "ltiple seperated by a comma";
-            // 
-            // label15
-            // 
-            this.label15.AutoSize = true;
-            this.label15.Location = new System.Drawing.Point(157, 154);
-            this.label15.Name = "label15";
-            this.label15.Size = new System.Drawing.Size(276, 13);
-            this.label15.TabIndex = 10;
-            this.label15.Text = "Default example sound: C:\\Windows\\Media\\Ring01.wav";
-            // 
-            // lblTestGridInfo
-            // 
-            this.lblTestGridInfo.AutoSize = true;
-            this.lblTestGridInfo.Location = new System.Drawing.Point(3, 567);
-            this.lblTestGridInfo.Name = "lblTestGridInfo";
-            this.lblTestGridInfo.Size = new System.Drawing.Size(109, 13);
-            this.lblTestGridInfo.TabIndex = 1;
-            this.lblTestGridInfo.Text = "Grid Results: Pending";
-            // 
-            // Selected
-            // 
-            this.Selected.HeaderText = "Selected";
-            this.Selected.Name = "Selected";
-            // 
-            // TestName
-            // 
-            this.TestName.HeaderText = "Test Name";
-            this.TestName.Name = "TestName";
-            this.TestName.ReadOnly = true;
-            this.TestName.Width = 200;
-            // 
-            // TestModule
-            // 
-            this.TestModule.HeaderText = "Module";
-            this.TestModule.Name = "TestModule";
-            this.TestModule.Width = 125;
-            // 
-            // Result
-            // 
-            this.Result.HeaderText = "Result";
-            this.Result.Name = "Result";
-            this.Result.ReadOnly = true;
-            // 
-            // LogFile
-            // 
-            this.LogFile.HeaderText = "Log File";
-            this.LogFile.Name = "LogFile";
-            this.LogFile.ReadOnly = true;
-            this.LogFile.Width = 310;
-            // 
-            // TestDescription
-            // 
-            this.TestDescription.HeaderText = "Description";
-            this.TestDescription.Name = "TestDescription";
-            this.TestDescription.Width = 400;
             // 
             // Form1
             // 

--- a/Form1.resx
+++ b/Form1.resx
@@ -123,10 +123,16 @@
   <metadata name="TestName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="TestModule.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="Result.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="LogFile.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="TestDescription.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
 </root>

--- a/LocalTestPortal.csproj
+++ b/LocalTestPortal.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions.cs" />
     <Compile Include="Form1.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -58,6 +59,7 @@
     <Compile Include="Setting.cs" />
     <Compile Include="SettingGroup.cs" />
     <Compile Include="SettingsModel.cs" />
+    <Compile Include="TestReader.cs" />
     <Compile Include="XMLHelper.cs" />
     <EmbeddedResource Include="Form1.resx">
       <DependentUpon>Form1.cs</DependentUpon>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,10 +1,6 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("LocalTestPortal")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
@@ -13,24 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6a674c35-dedf-43a9-b7d4-ee00090d59cf")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/Setting.cs
+++ b/Setting.cs
@@ -5,6 +5,7 @@ namespace LocalTestPortal
     internal class Setting
     {
         internal static readonly string TestProjectPath = "TestProjectPath";
+        internal static readonly string TestDllFileNames = "TestDllFileNames";
         internal static readonly string PlaySound = "PlaySound";
         internal static readonly string SQLServer = "SQLServer";
         internal static readonly string DBName = "DBName";

--- a/SettingsModel.cs
+++ b/SettingsModel.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace LocalTestPortal
 {
@@ -15,6 +11,7 @@ namespace LocalTestPortal
 
             Name = settingsName;
             TestProjectPath = xmlHelper.ReadSetting(SettingGroup.General, Setting.TestProjectPath);
+            TestDllFileNames = xmlHelper.ReadSetting(SettingGroup.General, Setting.TestDllFileNames).ToSplitList();
             PlaySound = xmlHelper.ReadSetting(SettingGroup.General, Setting.PlaySound);
 
             SQLServer = xmlHelper.ReadSetting(SettingGroup.Database, Setting.SQLServer);
@@ -36,7 +33,15 @@ namespace LocalTestPortal
 
         internal XMLHelper xmlHelper { get;  set; }
         public string Name { get; private set; }
-        public string TestProjectPath { get;  set; }
+        /// <summary>
+        /// Root path where the TestProject.exe and Test dll files exist
+        /// </summary>
+        public string TestProjectPath { get; set; }
+        public string TestProjectExe => "TestProject.exe";
+        /// <summary>
+        /// All dll test file names to use to load tests from
+        /// </summary>
+        public List<string> TestDllFileNames { get; set; }
         public string PlaySound { get;  set; }
         public string SQLServer { get;  set; }
         public string DBName { get;  set; }
@@ -59,6 +64,7 @@ namespace LocalTestPortal
         internal void Save()
         {
             xmlHelper.SaveSetting(SettingGroup.General, Setting.TestProjectPath, TestProjectPath);
+            xmlHelper.SaveSetting(SettingGroup.General, Setting.TestDllFileNames, TestDllFileNames.ToJoinedString());
             xmlHelper.SaveSetting(SettingGroup.General, Setting.PlaySound, PlaySound);
 
             xmlHelper.SaveSetting(SettingGroup.Database, Setting.SQLServer, SQLServer);
@@ -81,5 +87,4 @@ namespace LocalTestPortal
             xmlHelper.BuildRunnerExample(testName);
         }
     }
-
 }

--- a/TestReader.cs
+++ b/TestReader.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace LocalTestPortal
+{
+    /// <summary>
+    /// Reading of test dll to pull out all available tests
+    /// </summary>
+    internal class TestReader
+    {
+        private List<string> _DllFileNames;
+        private List<string> _TestsSimple;
+        private List<Test> _Tests;
+        private Type[] _CoreTestTypes;
+        private Type _CheckType;
+        private Type _TestDescriptionType;
+        private Type _TestIgnoreType;
+        private PropertyInfo _TestDescriptionPropertyInfo;
+
+        public readonly string TestPath;
+        public List<string> TestsSimple => _TestsSimple;
+        public List<Test> Tests => _Tests;
+        public List<string> DllFileNames => _DllFileNames;
+
+        public TestReader(string testsPath)
+        {
+            if(string.IsNullOrWhiteSpace(testsPath))
+            {
+                throw new ArgumentNullException(nameof(testsPath));
+            }
+
+            if (!Directory.Exists(testsPath))
+            {
+                throw new DirectoryNotFoundException($"Tests path is invalid: {testsPath}");
+            }
+
+            TestPath = testsPath;
+            _DllFileNames = new List<string>();
+            _TestsSimple = new List<string>();
+            _Tests = new List<Test>();
+
+            var coreDll = Path.Combine(TestPath, "PX.QA.Tools.dll");
+            if (!File.Exists(coreDll))
+            {
+                throw new FileNotFoundException("Unable to load Core.dll");
+            }
+
+            _CoreTestTypes = GetTestFileTypes(coreDll);
+            _CheckType = _CoreTestTypes.Where(t => t.FullName == "Core.TestExecution.Check").FirstOrDefault();
+            _TestDescriptionType = _CoreTestTypes.Where(t => t.FullName == "Core.Attributes.TestDescription").FirstOrDefault();
+            _TestIgnoreType = _CoreTestTypes.Where(t => t.FullName == "Core.Attributes.TestIgnoreAttribute").FirstOrDefault();
+            if(_TestDescriptionType != null)
+            {
+                _TestDescriptionPropertyInfo =  _TestDescriptionType.GetProperty("Description", typeof(string));
+            }
+        }
+
+        private string FormatDllFileName(string fileName)
+        {
+            if(string.IsNullOrWhiteSpace(fileName))
+            {
+                return null;
+            }
+
+            if(fileName.Contains("dll"))
+            {
+                return fileName.Trim();
+            }
+
+            return $"{fileName.Trim()}.dll";
+        }
+
+        private bool IsTestClass(Type item)
+        {
+            return item.IsSubclassOf(_CheckType);
+        }
+
+        private bool IsTestIgnore(Type item)
+        {
+            return item.CustomAttributes.Where(x => x.AttributeType.FullName == _TestIgnoreType.FullName).Any();
+        }
+
+        private Type[] GetTestFileTypes(string file)
+        {
+            return Assembly.LoadFrom(file).GetTypes();
+        }
+
+        private string GetTestDescription(Type item)
+        {
+            var att = item.GetCustomAttributes().FirstOrDefault(x => x.GetType() == _TestDescriptionType);
+            if(att == null || _TestDescriptionPropertyInfo == null)
+            {
+                return string.Empty;
+            }
+
+            return (string)_TestDescriptionPropertyInfo.GetValue(att) ?? string.Empty;
+        }
+
+        private string GetTestModule(Type item)
+        {
+            foreach(var att in item.GetCustomAttributes())
+            {
+                var attType = att.GetType();
+                if(attType.Namespace.StartsWith("Acumatica"))
+                {
+                    return attType.Name.Replace("Attribute","");
+                }
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Convert a test <see cref="Type"/> to custom <see cref="Test"/> object
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        private Test TypeToTest(Type item)
+        {
+            return new Test
+            {
+                Name = item.Name,
+                FullName = item.FullName,
+                Description = GetTestDescription(item),
+                Module = GetTestModule(item)
+            };
+        }
+
+        public void LoadTestDll(string dllFileName)
+        {
+            if(string.IsNullOrWhiteSpace(dllFileName))
+            {
+                throw new ArgumentNullException(nameof(dllFileName));
+            }
+
+            var formatedDllFileName = FormatDllFileName(dllFileName);
+            var testDllFile = Path.Combine(TestPath, formatedDllFileName);
+            if (!File.Exists(testDllFile))
+            {
+                throw new FileNotFoundException($"Test dll file is invalid: {testDllFile}");
+            }
+
+            _DllFileNames.Add(formatedDllFileName);
+
+            foreach (var item in GetTestFileTypes(testDllFile))
+            {
+                if(item.IsAbstract || !IsTestClass(item) || IsTestIgnore(item))
+                {
+                    continue;
+                }
+
+                _TestsSimple.Add(item.Name);
+                _Tests.Add(TypeToTest(item));
+            }
+        }
+
+        public class Test
+        {
+            public string Name;
+            public string FullName;
+            public string Description;
+            public string Module;
+        }
+    }
+}


### PR DESCRIPTION
This change allows the user to pick which test dll files to load tests from. It will also pull attributes from the tests to show in the grid to group by module and see test descriptions.

also call grid cells by name (vs index)

Fix fixed call to testproject.exe when kicking off test