### PR TITLE
when first run if directory does not exist there will be errors

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -363,6 +363,10 @@ namespace LocalTestPortal
         private void DeleteFiles(string folder, string extension)
         {
             DirectoryInfo di = new DirectoryInfo(folder);
+            if (!di.Exists)
+            {
+                return;
+            }
             FileInfo[] files = di.GetFiles("*" + extension)
                                  .Where(p => p.Extension == extension).ToArray();
             foreach (FileInfo file in files)
@@ -388,6 +392,11 @@ namespace LocalTestPortal
         {
             //this deletes all the folders in a directory but not the directory itself
             var dir = new DirectoryInfo(directrory);
+            if (!dir.Exists)
+            {
+                return;
+            }
+
             foreach(var folder in dir.GetDirectories())
             {
                 folder.Delete(true);


### PR DESCRIPTION
If first test where either output directory was deleted or first time running using that output directory folder name an error is received on the first test run